### PR TITLE
Improve compatibility for mac

### DIFF
--- a/download_dataset.sh
+++ b/download_dataset.sh
@@ -9,9 +9,10 @@ cd data
 URL="https://huggingface.co/datasets/commaai/commaSteeringControl/resolve/main/data/SYNTHETIC_V0.zip"
 
 echo "Downloading dataset from $URL"
-wget "$URL"
 
-ZIP_FILE="${URL##*/}"
+ZIP_FILE="dataset.zip"
+
+curl -L "$URL" -o $ZIP_FILE
 
 echo "Unzipping $ZIP_FILE"
 unzip -jq "$ZIP_FILE"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy==1.25.2
-onnxruntime-gpu==1.16.3
+onnxruntime==1.16.3
+onnxruntime-gpu==1.16.3; sys_platform != 'darwin'
 pandas==2.1.2
 matplotlib==3.8.1
 seaborn==0.13.2


### PR DESCRIPTION
Fixes:
- make the downloader script work on mac (wget isn't available by default)
- fix deps so that at least mac gets CPU provider running

I imagine this works on linux as well but haven't tested it out.


`onnxruntime-gpu` is not available for mac ([see platform matrix](https://onnxruntime.ai/getting-started))

I've tried to get the CoreML provider to work but I'm having trouble getting it all the way through so I haven't included that work here. Help would be appreciated.
